### PR TITLE
Update CI workflow and package configurations

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -9,74 +9,25 @@ on:
 jobs:
   unit-test:
     name: Unit tests (${{ matrix.name }})
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: macos-15
     strategy:
       matrix:
         include:
-        # 2024 versions
         - name: iOS 18
-          runs-on: macos-15
-          xcode-version: Xcode_16.4
           destination: platform=iOS Simulator,OS=18.5,name=iPhone 16
         - name: macOS 15
-          runs-on: macos-15
-          xcode-version: Xcode_16.4
           destination: platform=macOS
         - name: tvOS 18
-          runs-on: macos-15
-          xcode-version: Xcode_16.4
           destination: platform=tvOS Simulator,OS=18.5,name=Apple TV 4K (3rd generation)
         - name: visionOS 2
-          runs-on: macos-15
-          xcode-version: Xcode_16.4
           destination: platform=visionOS Simulator,OS=2.5,name=Apple Vision Pro
         - name: watchOS 11
-          runs-on: macos-15
-          xcode-version: Xcode_16.4
           destination: platform=watchOS Simulator,OS=11.5,name=Apple Watch Series 10 (42mm)
-        # 2023 versions (build-only due to no Swift Testing)
-        - name: iOS 17
-          runs-on: macos-14
-          xcode-version: Xcode_15.4
-          destination: platform=iOS Simulator,OS=17.5,name=iPhone 15
-        - name: macOS 14
-          runs-on: macos-14
-          xcode-version: Xcode_15.4
-          destination: platform=macOS
-        - name: tvOS 17
-          runs-on: macos-14
-          xcode-version: Xcode_15.4
-          destination: platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation)
-        - name: visionOS 1
-          runs-on: macos-14
-          xcode-version: Xcode_15.4
-          destination: platform=visionOS Simulator,OS=1.2,name=Apple Vision Pro
-        - name: watchOS 10
-          runs-on: macos-14
-          xcode-version: Xcode_15.4
-          destination: platform=watchOS Simulator,OS=10.5,name=Apple Watch Series 9 (41mm)
-        # 2022 versions (build-only due to no Swift Testing)
-        - name: iOS 16
-          runs-on: macos-13
-          xcode-version: Xcode_14.3.1
-          destination: platform=iOS Simulator,OS=16.4,name=iPhone 14
-        - name: macOS 13
-          runs-on: macos-13
-          xcode-version: Xcode_14.3.1
-          destination: platform=macOS
-        - name: tvOS 16
-          runs-on: macos-13
-          xcode-version: Xcode_14.3.1
-          destination: platform=tvOS Simulator,OS=16.4,name=Apple TV 4K (3rd generation)
-        - name: watchOS 9
-          runs-on: macos-13
-          xcode-version: Xcode_14.3.1
-          destination: platform=watchOS Simulator,OS=9.4,name=Apple Watch Series 8 (41mm)
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Select Xcode version
-      run: sudo xcode-select -s /Applications/${{ matrix.xcode-version }}.app
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app
     - name: Build and run tests
       run: xcrun xcodebuild test -scheme TMDB -resultBundlePath Artifacts/TestResults.xcresult -destination "${{ matrix.destination }}" CODE_SIGNING_ALLOWED=NO SWIFT_TREAT_WARNINGS_AS_ERRORS=YES
     - name: Upload xcresult bundle

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.0
 
 import PackageDescription
 

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 6.1
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+#  TMDB
+
+[![Swift Version Compatibility Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Figorcamilo%2Ftmdb-swift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/igorcamilo/tmdb-swift)
+[![Platform Compatibility Badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Figorcamilo%2Ftmdb-swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/igorcamilo/tmdb-swift)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/igorcamilo/tmdb-swift/main-branch.yml)](https://github.com/igorcamilo/tmdb-swift/actions/workflows/main-branch.yml)

--- a/Sources/TMDB/Client.swift
+++ b/Sources/TMDB/Client.swift
@@ -5,7 +5,14 @@
 //  Created by Igor Camilo on 16.07.25.
 //
 
+#if swift(>=6.0)
 import Foundation
+#else
+@preconcurrency import Foundation
+#endif
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public final class Client: Sendable {
     public let accessToken: String

--- a/Sources/TMDB/Models/Configuration.swift
+++ b/Sources/TMDB/Models/Configuration.swift
@@ -5,7 +5,11 @@
 //  Created by Igor Camilo on 16.07.25.
 //
 
+#if swift(>=6.0)
 import Foundation
+#else
+@preconcurrency import Foundation
+#endif
 
 public struct Configuration: Codable, Hashable, Sendable {
     public var changeKeys: [String]

--- a/Sources/TMDB/Models/Response.swift
+++ b/Sources/TMDB/Models/Response.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public struct Response: Codable, Hashable, Sendable {
     public var data: Data

--- a/Tests/TMDBTests/ClientTests.swift
+++ b/Tests/TMDBTests/ClientTests.swift
@@ -5,9 +5,10 @@
 //  Created by Igor Camilo on 16.07.25.
 //
 
-#if swift(>=6.0)
-
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Testing
 import TMDB
 
@@ -88,5 +89,3 @@ struct ClientTests {
         )
     }
 }
-
-#endif


### PR DESCRIPTION
- Set macOS version for CI unit tests to 15
- Update Swift tools version to 6.2 in Package.swift
- Add Package.swift for Swift 6.0 and 6.1
- Enhance README with compatibility badges
- Improve Client, Configuration, and Response models with
  FoundationNetworking imports
- Remove runs in older Xcode versions as
  these are now handled by Swift Package Index.