### PR TITLE
Add license file

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -13,15 +13,15 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: iOS 18
+        - name: iOS
           destination: platform=iOS Simulator,OS=18.5,name=iPhone 16
-        - name: macOS 15
+        - name: macOS
           destination: platform=macOS
-        - name: tvOS 18
+        - name: tvOS
           destination: platform=tvOS Simulator,OS=18.5,name=Apple TV 4K (3rd generation)
-        - name: visionOS 2
+        - name: visionOS
           destination: platform=visionOS Simulator,OS=2.5,name=Apple Vision Pro
-        - name: watchOS 11
+        - name: watchOS
           destination: platform=watchOS Simulator,OS=11.5,name=Apple Watch Series 10 (42mm)
     steps:
     - name: Checkout repository

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Igor Camilo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Updated the CI workflow to simplify platform names for iOS, macOS,
tvOS, visionOS, and watchOS. This improves clarity and consistency
in the configuration.