### PR TITLE
Add similar movies & TV shows

### DIFF
--- a/Sources/TMDB/Movies/MovieList.swift
+++ b/Sources/TMDB/Movies/MovieList.swift
@@ -1,17 +1,29 @@
 public enum MovieList: Codable, Hashable, Identifiable, Sendable {
+    /// Movies that are currently in theatres.
     case nowPlaying
+    /// Movies ordered by popularity.
     case popular
+    /// Movies ordered by rating.
     case topRated
+    /// Movies that are being released soon.
     case upcoming
+    /// Similar movies based on genres and keywords.
+    case similar(Movie.ID)
 
     public var id: Self { self }
 
     var pathComponent: String {
         switch self {
-        case .nowPlaying: return "movie/now_playing"
-        case .popular: return "movie/popular"
-        case .topRated: return "movie/top_rated"
-        case .upcoming: return "movie/upcoming"
+        case .nowPlaying:
+            "movie/now_playing"
+        case .popular:
+            "movie/popular"
+        case .topRated:
+            "movie/top_rated"
+        case .upcoming:
+            "movie/upcoming"
+        case let .similar(id):
+            "movie/\(id.rawValue)/similar"
         }
     }
 }

--- a/Sources/TMDB/TVShows/TVShowList.swift
+++ b/Sources/TMDB/TVShows/TVShowList.swift
@@ -1,17 +1,29 @@
 public enum TVShowList: Codable, Hashable, Identifiable, Sendable {
+    /// TV shows airing today.
     case airingToday
+    /// TV shows that air in the next 7 days.
     case onTheAir
+    /// TV shows ordered by popularity.
     case popular
+    /// TV shows ordered by rating.
     case topRated
+    /// Similar TV shows based on genres and keywords.
+    case similar(TVShow.ID)
 
     public var id: Self { self }
 
     var pathComponent: String {
         switch self {
-        case .airingToday: return "tv/airing_today"
-        case .onTheAir: return "tv/on_the_air"
-        case .popular: return "tv/popular"
-        case .topRated: return "tv/top_rated"
+        case .airingToday:
+            "tv/airing_today"
+        case .onTheAir:
+            "tv/on_the_air"
+        case .popular:
+            "tv/popular"
+        case .topRated:
+            "tv/top_rated"
+        case let .similar(id):
+            "tv/\(id.rawValue)/similar"
         }
     }
 }

--- a/Tests/TMDBTests/Movies/ClientMovieTests.swift
+++ b/Tests/TMDBTests/Movies/ClientMovieTests.swift
@@ -12,6 +12,7 @@ struct ClientMovieTests {
             (MovieList.popular, "https://api.themoviedb.org/3/movie/popular"),
             (MovieList.topRated, "https://api.themoviedb.org/3/movie/top_rated"),
             (MovieList.upcoming, "https://api.themoviedb.org/3/movie/upcoming"),
+            (MovieList.similar(Movie.ID(rawValue: 123)), "https://api.themoviedb.org/3/movie/123/similar"),
         ]
     )
     func moviesSuccess(list: MovieList, absoluteURLString: String) async throws {
@@ -44,6 +45,7 @@ struct ClientMovieTests {
             (MovieList.popular, "https://api.themoviedb.org/3/movie/popular"),
             (MovieList.topRated, "https://api.themoviedb.org/3/movie/top_rated"),
             (MovieList.upcoming, "https://api.themoviedb.org/3/movie/upcoming"),
+            (MovieList.similar(Movie.ID(rawValue: 456)), "https://api.themoviedb.org/3/movie/456/similar"),
         ]
     )
     func moviesFailureResponse(list: MovieList, absoluteURLString: String) async throws {
@@ -76,6 +78,7 @@ struct ClientMovieTests {
             (MovieList.popular, "https://api.themoviedb.org/3/movie/popular"),
             (MovieList.topRated, "https://api.themoviedb.org/3/movie/top_rated"),
             (MovieList.upcoming, "https://api.themoviedb.org/3/movie/upcoming"),
+            (MovieList.similar(Movie.ID(rawValue: 789)), "https://api.themoviedb.org/3/movie/789/similar"),
         ]
     )
     func moviesFailureRequest(list: MovieList, absoluteURLString: String) async throws {

--- a/Tests/TMDBTests/TVShows/ClientTVShowTests.swift
+++ b/Tests/TMDBTests/TVShows/ClientTVShowTests.swift
@@ -12,6 +12,7 @@ struct ClientTVShowTests {
             (TVShowList.onTheAir, "https://api.themoviedb.org/3/tv/on_the_air"),
             (TVShowList.popular, "https://api.themoviedb.org/3/tv/popular"),
             (TVShowList.topRated, "https://api.themoviedb.org/3/tv/top_rated"),
+            (TVShowList.similar(TVShow.ID(rawValue: 123)), "https://api.themoviedb.org/3/tv/123/similar"),
         ]
     )
     func tvShowsSuccess(list: TVShowList, absoluteURLString: String) async throws {
@@ -44,6 +45,7 @@ struct ClientTVShowTests {
             (TVShowList.onTheAir, "https://api.themoviedb.org/3/tv/on_the_air"),
             (TVShowList.popular, "https://api.themoviedb.org/3/tv/popular"),
             (TVShowList.topRated, "https://api.themoviedb.org/3/tv/top_rated"),
+            (TVShowList.similar(TVShow.ID(rawValue: 456)), "https://api.themoviedb.org/3/tv/456/similar"),
         ]
     )
     func tvShowsFailureResponse(list: TVShowList, absoluteURLString: String) async throws {
@@ -76,6 +78,7 @@ struct ClientTVShowTests {
             (TVShowList.onTheAir, "https://api.themoviedb.org/3/tv/on_the_air"),
             (TVShowList.popular, "https://api.themoviedb.org/3/tv/popular"),
             (TVShowList.topRated, "https://api.themoviedb.org/3/tv/top_rated"),
+            (TVShowList.similar(TVShow.ID(rawValue: 789)), "https://api.themoviedb.org/3/tv/789/similar"),
         ]
     )
     func tvShowsFailureRequest(list: TVShowList, absoluteURLString: String) async throws {


### PR DESCRIPTION
This pull request introduces new functionality for handling "similar" movies and TV shows in the TMDB client, along with corresponding updates to the test suite. The most important changes include adding a new `similar` case to the `MovieList` and `TVShowList` enums, updating the `pathComponent` logic to support these cases, and extending the test coverage to ensure the new functionality works as expected.

### Enhancements to `MovieList` and `TVShowList` enums:
* Added a `similar` case to the `MovieList` enum, which accepts a `Movie.ID` parameter to fetch movies similar to a specific movie. Updated the `pathComponent` logic to generate the appropriate API path for this case. (`Sources/TMDB/Movies/MovieList.swift`, [Sources/TMDB/Movies/MovieList.swiftR2-R26](diffhunk://#diff-184ac33bbe7522d12fe7835458e2ff8264bac5122e31449933981108094347a1R2-R26))
* Added a `similar` case to the `TVShowList` enum, which accepts a `TVShow.ID` parameter to fetch TV shows similar to a specific show. Updated the `pathComponent` logic to generate the appropriate API path for this case. (`Sources/TMDB/TVShows/TVShowList.swift`, [Sources/TMDB/TVShows/TVShowList.swiftR2-R26](diffhunk://#diff-761e2b984ed172d7bc1147f8c11bb15cbcee29d9de4df75086ae53fff039a89cR2-R26))

### Test suite updates:
* Extended `ClientMovieTests` to include test cases for the `similar` case in `MovieList`, verifying the correct API paths for various movie IDs. (`Tests/TMDBTests/Movies/ClientMovieTests.swift`, [[1]](diffhunk://#diff-2f485070885e22d0d7541c51284defa291edbe8a8527cb2aa237bf8992466158R15) [[2]](diffhunk://#diff-2f485070885e22d0d7541c51284defa291edbe8a8527cb2aa237bf8992466158R48) [[3]](diffhunk://#diff-2f485070885e22d0d7541c51284defa291edbe8a8527cb2aa237bf8992466158R81)
* Extended `ClientTVShowTests` to include test cases for the `similar` case in `TVShowList`, verifying the correct API paths for various TV show IDs. (`Tests/TMDBTests/TVShows/ClientTVShowTests.swift`, [[1]](diffhunk://#diff-c49be26a9d1dfeaae2bc25a17de23933542c0a24aa4ad457c5debba4e28d8e50R15) [[2]](diffhunk://#diff-c49be26a9d1dfeaae2bc25a17de23933542c0a24aa4ad457c5debba4e28d8e50R48) [[3]](diffhunk://#diff-c49be26a9d1dfeaae2bc25a17de23933542c0a24aa4ad457c5debba4e28d8e50R81)