### PR TITLE
Fix nullability of models

### DIFF
--- a/Sources/TMDB/Movies/Movie.swift
+++ b/Sources/TMDB/Movies/Movie.swift
@@ -1,13 +1,13 @@
 public struct Movie: Codable, Hashable, Sendable {
     public var adult: Bool
-    public var backdropPath: String
+    public var backdropPath: String?
     public var genreIDs: [Genre.ID]
     public var id: ID
     public var originalLanguage: String
     public var originalTitle: String
     public var overview: String
     public var popularity: Double
-    public var posterPath: String
+    public var posterPath: String?
     public var releaseDate: String
     public var title: String
     public var video: Bool
@@ -16,14 +16,14 @@ public struct Movie: Codable, Hashable, Sendable {
 
     public init(
         adult: Bool,
-        backdropPath: String,
+        backdropPath: String?,
         genreIDs: [Genre.ID],
         id: ID,
         originalLanguage: String,
         originalTitle: String,
         overview: String,
         popularity: Double,
-        posterPath: String,
+        posterPath: String?,
         releaseDate: String,
         title: String,
         video: Bool,

--- a/Sources/TMDB/TVShows/TVShow.swift
+++ b/Sources/TMDB/TVShows/TVShow.swift
@@ -1,6 +1,6 @@
 public struct TVShow: Codable, Hashable, Sendable {
     public var adult: Bool
-    public var backdropPath: String
+    public var backdropPath: String?
     public var genreIDs: [Genre.ID]
     public var id: ID
     public var originCountry: [String]
@@ -8,7 +8,7 @@ public struct TVShow: Codable, Hashable, Sendable {
     public var originalName: String
     public var overview: String
     public var popularity: Double
-    public var posterPath: String
+    public var posterPath: String?
     public var firstAirDate: String
     public var name: String
     public var voteAverage: Double
@@ -16,7 +16,7 @@ public struct TVShow: Codable, Hashable, Sendable {
 
     public init(
         adult: Bool,
-        backdropPath: String,
+        backdropPath: String?,
         genreIDs: [Genre.ID],
         id: ID,
         originCountry: [String],
@@ -24,7 +24,7 @@ public struct TVShow: Codable, Hashable, Sendable {
         originalName: String,
         overview: String,
         popularity: Double,
-        posterPath: String,
+        posterPath: String?,
         firstAirDate: String,
         name: String,
         voteAverage: Double,

--- a/Tests/TMDBTests/Movies/Data+MoviePageContent.swift
+++ b/Tests/TMDBTests/Movies/Data+MoviePageContent.swift
@@ -396,7 +396,7 @@ private let content = #"""
         },
         {
             "adult": false,
-            "backdrop_path": "/apNfldKI3RiaukNwJzr8EjRG7Wc.jpg",
+            "backdrop_path": null,
             "genre_ids": [
                 53,
                 878
@@ -406,7 +406,7 @@ private let content = #"""
             "original_title": "Brick",
             "overview": "When a mysterious brick wall encloses their apartment building overnight, Tim and Olivia must unite with their wary neighbors to get out alive.",
             "popularity": 115.2344,
-            "poster_path": "/vTX9CxFNEQOlfXsgqec7xmc5UtD.jpg",
+            "poster_path": null,
             "release_date": "2025-07-09",
             "title": "Brick",
             "video": false,

--- a/Tests/TMDBTests/TVShows/Data+TVShowPageContent.swift
+++ b/Tests/TMDBTests/TVShows/Data+TVShowPageContent.swift
@@ -418,7 +418,7 @@ private let content = #"""
         },
         {
             "adult": false,
-            "backdrop_path": "/yVIudr5ZNtFvomu6CdFGKAa3njk.jpg",
+            "backdrop_path": null,
             "genre_ids": [
                 35,
                 18,
@@ -432,7 +432,7 @@ private let content = #"""
             "original_name": "SpangaS",
             "overview": "Best Friends follows the life of a group of friends at their high school ‘Spangalis College’. Inside and outside of school exciting and challenging experiences take place. Growing up is never easy; every character has its own, unique story of love, friendship, loneliness, sorrow, discovery. There is drama and joy in school, family, teachers, parents, divorce, bullying, and always dreams for the future.",
             "popularity": 276.4241,
-            "poster_path": "/2bH7QQ7WQfnbt1CWiX8BE5E2V4t.jpg",
+            "poster_path": null,
             "first_air_date": "2007-09-03",
             "name": "Best Friends",
             "vote_average": 3,


### PR DESCRIPTION
This pull request introduces changes to make the `backdropPath` and `posterPath` properties optional in the `Movie` and `TVShow` models. Corresponding test data has also been updated to reflect these changes. This improves the robustness of the code when handling cases where these paths may be absent.

### Changes to models:
* Updated `backdropPath` and `posterPath` properties in the `Movie` model to be optional (`String?`) instead of non-optional (`String`). (`Sources/TMDB/Movies/Movie.swift`, [[1]](diffhunk://#diff-2b994f0d0c30bb7579d6ae371cfb0e4e54a162c0fed68a483a0caba64feebe32L3-R10) [[2]](diffhunk://#diff-2b994f0d0c30bb7579d6ae371cfb0e4e54a162c0fed68a483a0caba64feebe32L19-R26)
* Updated `backdropPath` and `posterPath` properties in the `TVShow` model to be optional (`String?`) instead of non-optional (`String`). (`Sources/TMDB/TVShows/TVShow.swift`, [Sources/TMDB/TVShows/TVShow.swiftL3-R27](diffhunk://#diff-a2e1b451a2cf4c0d1243df185b0fc3c705d32fe0a6b3e63d5de278507fe8693cL3-R27))

### Changes to test data:
* Modified `backdrop_path` and `poster_path` values to `null` in the `Movie` test data to align with the updated model. (`Tests/TMDBTests/Movies/Data+MoviePageContent.swift`, [[1]](diffhunk://#diff-d33e494958b2e1cc1f43ce939c2f2eaa4eab855566696a30e3384dfe78e32eb6L399-R399) [[2]](diffhunk://#diff-d33e494958b2e1cc1f43ce939c2f2eaa4eab855566696a30e3384dfe78e32eb6L409-R409)
* Modified `backdrop_path` and `poster_path` values to `null` in the `TVShow` test data to align with the updated model. (`Tests/TMDBTests/TVShows/Data+TVShowPageContent.swift`, [[1]](diffhunk://#diff-a67e8bd9774300b7c831fedc7b8afd62178ba30d49e97b6a0edecd60b24cb8b6L421-R421) [[2]](diffhunk://#diff-a67e8bd9774300b7c831fedc7b8afd62178ba30d49e97b6a0edecd60b24cb8b6L435-R435)