### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,6 +10,8 @@ jobs:
   swift-linter:
     name: Swift linter
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,8 +10,6 @@ jobs:
   swift-linter:
     name: Swift linter
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,27 @@
+name: "Linting"
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+permissions:
+  contents: read
+jobs:
+  swift-linter:
+    name: Swift linter
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Swift
+      run: |
+        sudo apt-get -y install libcurl4-openssl-dev
+        curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz
+        tar zxf swiftly-$(uname -m).tar.gz
+        ./swiftly init --skip-install --quiet-shell-followup
+        . "${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}/env.sh"
+        hash -r
+        swiftly install
+        swift --version
+    - name: Lint code
+      run: swift format lint . -rps

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,42 @@
+name: "Security"
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.name }})
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-15') || 'ubuntu-24.04' }}
+    permissions:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: GitHub Actions
+          language: actions
+          build-mode: none
+        - name: Swift
+          language: swift
+          build-mode: manual
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+    - if: matrix.language == 'swift'
+      name: Select Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_16.4.app
+    - if: matrix.language == 'swift'
+      name: Build with Xcode
+      run: xcrun xcodebuild -scheme TMDB CODE_SIGNING_ALLOWED=NO
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,7 +7,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
 jobs:
-  analyze:
+  codeql:
     name: CodeQL (${{ matrix.name }})
     runs-on: ${{ (matrix.language == 'swift' && 'macos-15') || 'ubuntu-24.04' }}
     permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ "main" ]
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 0'
 jobs:
   codeql:
     name: CodeQL (${{ matrix.name }})

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,24 @@ jobs:
         - name: GitHub Actions
           language: actions
           build-mode: none
-        - name: Swift
+        - name: Swift iOS
+          destination: platform=iOS Simulator,arch=arm64,OS=18.5,name=iPhone 16
+          language: swift
+          build-mode: manual
+        - name: Swift macOS
+          destination: platform=macOS,arch=arm64
+          language: swift
+          build-mode: manual
+        - name: Swift tvOS
+          destination: platform=tvOS Simulator,arch=arm64,OS=18.5,name=Apple TV 4K (3rd generation)
+          language: swift
+          build-mode: manual
+        - name: Swift visionOS
+          destination: platform=visionOS Simulator,arch=arm64,OS=2.5,name=Apple Vision Pro
+          language: swift
+          build-mode: manual
+        - name: Swift watchOS
+          destination: platform=watchOS Simulator,arch=arm64,OS=11.5,name=Apple Watch Series 10 (42mm)
           language: swift
           build-mode: manual
     steps:
@@ -35,7 +52,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_16.4.app
     - if: matrix.language == 'swift'
       name: Build with Xcode
-      run: xcrun xcodebuild -scheme TMDB CODE_SIGNING_ALLOWED=NO
+      run: xcrun xcodebuild -scheme TMDB -destination "${{ matrix.destination }}" CODE_SIGNING_ALLOWED=NO
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,15 +24,11 @@ jobs:
           language: swift
           build-mode: manual
         - name: Swift macOS
-          destination: platform=macOS,arch=arm64
+          destination: platform=macOS,arch=x86_64
           language: swift
           build-mode: manual
         - name: Swift tvOS
           destination: platform=tvOS Simulator,arch=arm64,OS=18.5,name=Apple TV 4K (3rd generation)
-          language: swift
-          build-mode: manual
-        - name: Swift visionOS
-          destination: platform=visionOS Simulator,arch=arm64,OS=2.5,name=Apple Vision Pro
           language: swift
           build-mode: manual
         - name: Swift watchOS

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,8 +44,6 @@ jobs:
   swift-tests-macos:
     name: Swift tests (macOS)
     runs-on: macos-15
-    strategy:
-      fail-fast: false
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -63,8 +61,6 @@ jobs:
   swift-tests-ubuntu:
     name: Swift tests (Ubuntu)
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,13 +70,3 @@ jobs:
         swift --version
     - name: Build and run tests
       run: swift test -Xswiftc -warnings-as-errors
-  linter:
-    name: Swift linter
-    runs-on: macos-15
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Select Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_16.4.app
-    - name: Lint code
-      run: xcrun swift format lint . -rps

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,7 @@ jobs:
     name: Xcode tests (${{ matrix.name }})
     runs-on: macos-15
     strategy:
+      fail-fast: false
       matrix:
         include:
         - name: iOS
@@ -38,6 +39,8 @@ jobs:
   swift-tests-macos:
     name: Swift tests (macOS)
     runs-on: macos-15
+    strategy:
+      fail-fast: false
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -55,6 +58,8 @@ jobs:
   swift-tests-ubuntu:
     name: Swift tests (Ubuntu)
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,7 +30,12 @@ jobs:
     - name: Select Xcode version
       run: sudo xcode-select -s /Applications/Xcode_16.4.app
     - name: Build and run tests
-      run: xcrun xcodebuild test -scheme TMDB -resultBundlePath "Artifacts/TestResults (${{ matrix.name }}).xcresult" -destination "${{ matrix.destination }}" CODE_SIGNING_ALLOWED=NO SWIFT_TREAT_WARNINGS_AS_ERRORS=YES
+      run: xcrun xcodebuild test -scheme TMDB -resultBundlePath "Artifacts/TestResults (${{ matrix.name }}).xcresult" -destination "${{ matrix.destination }}" -enableCodeCoverage YES CODE_SIGNING_ALLOWED=NO SWIFT_TREAT_WARNINGS_AS_ERRORS=YES
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: igorcamilo/tmdb-swift
     - name: Upload Xcode result bundle
       uses: actions/upload-artifact@v4
       with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,100 @@
-#  TMDB
+
+# TMDB
 
 [![Swift](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Figorcamilo%2Ftmdb-swift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/igorcamilo/tmdb-swift)
 [![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Figorcamilo%2Ftmdb-swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/igorcamilo/tmdb-swift)
 [![Unit tests](https://github.com/igorcamilo/tmdb-swift/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/igorcamilo/tmdb-swift/actions/workflows/unit-tests.yml)
+
+Swift client for [The Movie Database (TMDB) API](https://www.themoviedb.org/documentation/api), supporting movies, TV shows, and configuration endpoints. Built for modern Swift and concurrency.
+
+---
+
+## Features
+
+- Fetch movies and TV shows by popularity, rating, trending, and more
+- Retrieve similar movies/TV shows
+- Access TMDB configuration (image base URLs, sizes, etc.)
+- Codable, Sendable, and concurrency-friendly API
+- Supports iOS, macOS, tvOS, and watchOS
+- 100% Swift, no dependencies
+- Unit tested
+
+## Requirements
+
+- Swift 5.10, 6.0, 6.1, or 6.2
+- iOS 13.0+, macOS 10.15+, tvOS 13.0+, watchOS 6.0+
+
+## Installation
+
+Add the package to your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/igorcamilo/tmdb-swift.git", from: "0.1.0")
+```
+
+Or use Xcode's Swift Package Manager integration.
+
+## Usage
+
+```swift
+import TMDB
+
+let client = Client(accessToken: "YOUR_TMDB_ACCESS_TOKEN")
+
+// Fetch popular movies
+let page = try await client.movies(list: .popular)
+for movie in page.results {
+    print(movie.title)
+}
+
+// Fetch trending TV shows
+let tvPage = try await client.tvShows(list: .trending(.day))
+for show in tvPage.results {
+    print(show.name)
+}
+
+// Fetch API configuration
+let config = try await client.configuration()
+print(config.images.baseURL)
+```
+
+## API Overview
+
+### Movies
+- `.nowPlaying` — In theatres
+- `.popular` — By popularity
+- `.topRated` — By rating
+- `.upcoming` — Coming soon
+- `.similar(Movie.ID)` — Similar movies
+- `.trending(TrendingTimeWindow)` — Trending
+
+### TV Shows
+- `.airingToday` — Airing today
+- `.onTheAir` — Next 7 days
+- `.popular` — By popularity
+- `.topRated` — By rating
+- `.similar(TVShow.ID)` — Similar shows
+- `.trending(TrendingTimeWindow)` — Trending
+
+### Configuration
+- `client.configuration()` — Get image base URLs, sizes, etc.
+
+## Running Tests
+
+Run all tests with:
+
+```sh
+swift test
+```
+
+## License
+
+MIT License. See [LICENSE](LICENSE).
+
+## Contributing
+
+Contributions are welcome! Please open issues or pull requests.
+
+---
+
+> This project is not affiliated with TMDB. You need your own TMDB API access token.

--- a/Sources/TMDB/Client.swift
+++ b/Sources/TMDB/Client.swift
@@ -26,7 +26,6 @@ public final class Client: Sendable {
   }
 
   func urlRequest() throws -> URLRequest {
-    let aaa = 123
     let baseURLString = "https://api.themoviedb.org/3/"
     guard let baseURL = URL(string: baseURLString) else {
       throw ClientError.invalidBaseURL(baseURLString)

--- a/Sources/TMDB/Client.swift
+++ b/Sources/TMDB/Client.swift
@@ -26,6 +26,7 @@ public final class Client: Sendable {
   }
 
   func urlRequest() throws -> URLRequest {
+    let aaa = 123
     let baseURLString = "https://api.themoviedb.org/3/"
     guard let baseURL = URL(string: baseURLString) else {
       throw ClientError.invalidBaseURL(baseURLString)


### PR DESCRIPTION
This pull request introduces several improvements to the CI/CD workflows, focusing on adding new workflows for linting and security analysis, enhancing test coverage reporting, and refining existing unit test workflows. Below is a summary of the most significant changes:

### New Workflows

* Added a new `Linting` workflow in `.github/workflows/linting.yml` to run Swift lint checks on code changes. It installs Swift on an Ubuntu runner and uses `swift format lint` for linting.
* Added a new `Security` workflow in `.github/workflows/security.yml` to perform CodeQL analysis for multiple languages, including Swift. It supports scheduled runs and matrix builds for different platforms and configurations.

### Enhancements to Unit Test Workflows

* Enabled code coverage in the `Build and run tests` step of the `Xcode tests` job in `.github/workflows/unit-tests.yml` and added a step to upload coverage reports to Codecov.
* Added `fail-fast: false` to the strategy of multiple jobs (`Xcode tests`, `swift-tests-macos`, and `swift-tests-ubuntu`) to ensure all test configurations run even if one fails. [[1]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3R14) [[2]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3R47-R48) [[3]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3R66-R67)

### Workflow Cleanup

* Removed the `linter` job from `.github/workflows/unit-tests.yml` as it has been moved to the new `Linting` workflow for better separation of concerns.